### PR TITLE
Add indentation width to project settings

### DIFF
--- a/Ongaku.xcodeproj/project.pbxproj
+++ b/Ongaku.xcodeproj/project.pbxproj
@@ -95,7 +95,9 @@
 				42024E0320145BFA00AEBA10 /* OngakuUITests */,
 				42024DE520145BFA00AEBA10 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		42024DE520145BFA00AEBA10 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Explicitly specify the indentation and tab width of the project, so
contributors with a default width differing from the Xcode default of
4 get the right settings automatically.