### PR TITLE
Improve song formatting

### DIFF
--- a/Ongaku/ViewController.swift
+++ b/Ongaku/ViewController.swift
@@ -95,16 +95,15 @@ class ViewController: NSViewController {
             // Something's marked as playing, time to see..
             let sureTrack = track!
 
+            presence.state = "\(sureTrack.artist!) \u{2014} \(sureTrack.album!)"
+            presence.assets.largeText = "\(sureTrack.name!)"
+            presence.assets.largeImage = assetName
+
             switch playerState {
             case .iTunesEPlSPlaying:
-                let name = sureTrack.name!
-                let album = sureTrack.artist!
-
-                presence.details = "\(name)"
-                presence.state = "\(album) - \(name)"
-                presence.assets.largeText = "\(name)"
+                presence.details = "\(sureTrack.name!)"
                 presence.assets.smallImage = "play"
-                presence.assets.smallText = "Actively playing"
+                presence.assets.smallText = "Playing"
 
                 // Determine if this song is available on the iTunes Store.
                 // It's okay if it is not - we default to the Music icon.
@@ -130,12 +129,9 @@ class ViewController: NSViewController {
                 // Add time remaining
                 presence.timestamps.end = Date(timeIntervalSince1970: endTimestamp.timeIntervalSince1970 * 1000)
             case .iTunesEPlSPaused:
-                presence.details = "Paused - \(sureTrack.name!)"
-                presence.state = "\(sureTrack.album!) - \(sureTrack.artist!)"
-                presence.assets.largeImage = assetName
-                presence.assets.largeText = "\(sureTrack.name!)"
+                presence.details = "Paused: \(sureTrack.name!)"
                 presence.assets.smallImage = "pause"
-                presence.assets.smallText = "Currently paused"
+                presence.assets.smallText = "Paused"
             default:
                 break
             }


### PR DESCRIPTION
> Format the rich presence state to include the artist and album name,
instead of the artist and track name. The track name is already included
in the details field, so its presence in the state field is superfluous.
> 
> Make the small text more succinct.
> 
> Furthermore, refactor the code paths and rename variables to be less
confusing.

![image](https://user-images.githubusercontent.com/4206232/154334905-782e01f5-9a96-45be-a4a6-35ff6cd9531e.png)
