### PR TITLE
Redesign player interface

### DIFF
--- a/Ongaku.xcodeproj/project.pbxproj
+++ b/Ongaku.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12F47205281D214A00609C94 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F47204281D214A00609C94 /* Track.swift */; };
+		12F47207281D21D600609C94 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F47206281D21D600609C94 /* Player.swift */; };
+		12F47209281D227B00609C94 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F47208281D227B00609C94 /* PlayerState.swift */; };
+		12F4720B281D2B6000609C94 /* MusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F4720A281D2B6000609C94 /* MusicPlayer.swift */; };
 		42024DE820145BFA00AEBA10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42024DE720145BFA00AEBA10 /* AppDelegate.swift */; };
 		42024DEA20145BFA00AEBA10 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42024DE920145BFA00AEBA10 /* ViewController.swift */; };
 		42024DEC20145BFA00AEBA10 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 42024DEB20145BFA00AEBA10 /* Assets.xcassets */; };
@@ -46,6 +50,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		12F47204281D214A00609C94 /* Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
+		12F47206281D21D600609C94 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
+		12F47208281D227B00609C94 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
+		12F4720A281D2B6000609C94 /* MusicPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayer.swift; sourceTree = "<group>"; };
 		42024DE420145BFA00AEBA10 /* Ongaku.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ongaku.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		42024DE720145BFA00AEBA10 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		42024DE920145BFA00AEBA10 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -87,6 +95,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		12F47203281D202700609C94 /* Player */ = {
+			isa = PBXGroup;
+			children = (
+				12F47204281D214A00609C94 /* Track.swift */,
+				12F47206281D21D600609C94 /* Player.swift */,
+				12F47208281D227B00609C94 /* PlayerState.swift */,
+				12F4720A281D2B6000609C94 /* MusicPlayer.swift */,
+			);
+			path = Player;
+			sourceTree = "<group>";
+		};
 		42024DDB20145BF900AEBA10 = {
 			isa = PBXGroup;
 			children = (
@@ -112,6 +131,7 @@
 		42024DE620145BFA00AEBA10 /* Ongaku */ = {
 			isa = PBXGroup;
 			children = (
+				12F47203281D202700609C94 /* Player */,
 				42E0BC98242929B10041F1C4 /* Ongaku.entitlements */,
 				42024DE720145BFA00AEBA10 /* AppDelegate.swift */,
 				42024DE920145BFA00AEBA10 /* ViewController.swift */,
@@ -285,8 +305,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				12F47209281D227B00609C94 /* PlayerState.swift in Sources */,
+				12F47207281D21D600609C94 /* Player.swift in Sources */,
+				12F4720B281D2B6000609C94 /* MusicPlayer.swift in Sources */,
 				42024DEA20145BFA00AEBA10 /* ViewController.swift in Sources */,
 				42024DE820145BFA00AEBA10 /* AppDelegate.swift in Sources */,
+				12F47205281D214A00609C94 /* Track.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ongaku/Player/Player.swift
+++ b/Ongaku/Player/Player.swift
@@ -1,0 +1,18 @@
+//
+//  Player.swift
+//  Ongaku
+//
+//  Created by Skip Rousseau on 4/30/22.
+//  Copyright © 2022 Spotlight Deveaux. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol Player {
+    /// A Combine subject that publishes the current player state.
+    var state: CurrentValueSubject<PlayerState, Never> { get }
+
+    /// Fetches a URL to the artwork of a track.
+    func fetchArtwork(forTrack track: Track) async throws -> URL?
+}

--- a/Ongaku/Player/PlayerState.swift
+++ b/Ongaku/Player/PlayerState.swift
@@ -1,0 +1,26 @@
+//
+//  PlayerState.swift
+//  Ongaku
+//
+//  Created by Skip Rousseau on 4/30/22.
+//  Copyright © 2022 Spotlight Deveaux. All rights reserved.
+//
+
+import Foundation
+
+enum PlayerState {
+    struct Active {
+        var track: Track
+        let position: TimeInterval
+    }
+
+    /// Indicates that the player was playing a track, but has been paused by
+    /// the user.
+    case paused(Active)
+
+    /// Indicates that the player is actively playing a track.
+    case playing(Active)
+
+    /// Indicates that the player is not playing anything.
+    case stopped
+}

--- a/Ongaku/Player/Track.swift
+++ b/Ongaku/Player/Track.swift
@@ -1,0 +1,26 @@
+//
+//  Track.swift
+//  Ongaku
+//
+//  Created by Skip Rousseau on 4/30/22.
+//  Copyright © 2022 Spotlight Deveaux. All rights reserved.
+//
+
+import Foundation
+
+struct Track {
+    /// The title of the track.
+    let title: String
+
+    /// The name of the album the track is contained within.
+    let album: String?
+
+    /// The name of the artist of the track.
+    let artist: String?
+
+    /// The duration of the track in seconds.
+    let duration: TimeInterval
+
+    /// The URL of this track.
+    var url: String?
+}

--- a/Ongaku/ViewController.swift
+++ b/Ongaku/ViewController.swift
@@ -7,48 +7,36 @@
 //
 
 import Cocoa
+import Combine
 import Foundation
-import MusicKit
-import ScriptingBridge
 import SwordRPC
+import os.log
 
-// Adapted from
-// https://gist.github.com/pvieito/3aee709b97602bfc44961df575e2b696
-@objc enum iTunesEPlS: NSInteger {
-    case iTunesEPlSStopped = 0x6B50_5353
-    case iTunesEPlSPlaying = 0x6B50_5350
-    case iTunesEPlSPaused = 0x6B50_5370
-    // others omitted
-}
-
-@objc protocol iTunesTrack {
-    @objc optional var album: String { get }
-    @objc optional var artist: String { get }
-    @objc optional var duration: CDouble { get }
-    @objc optional var name: String { get }
-    @objc optional var playerState: iTunesEPlS { get }
-    @objc optional var storeURL: String { get }
-}
-
-@objc protocol iTunesApplication {
-    @objc optional var currentTrack: iTunesTrack { get }
-    @objc optional var playerPosition: CDouble { get }
-}
+fileprivate let log: Logger = Logger(subsystem: "io.github.spotlightishere.Ongaku", category: "view-controller")
 
 class ViewController: NSViewController {
     // This is the Ongaku app ID.
     // You're welcome to change as you want.
     let rpc = SwordRPC(appId: "402370117901484042")
 
-    let appName = "com.apple.Music"
     var assetName = "big_sur_logo"
+
+    var player: Player!
+    var playerSink: AnyCancellable?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        do {
+            player = try MusicPlayer()
+        } catch {
+            log.error("Failed to construct MusicPlayer: \(error.localizedDescription)")
+            fatalError("Can't start -- failed to create MusicPlayer. \(error)")
+        }
+
         // Callback for when RPC connects.
         rpc.onConnect { _ in
-            print("Connected to Discord.")
+            log.notice("Connected to Discord RPC.")
 
             DispatchQueue.main.async {
                 // Bye window :)
@@ -58,141 +46,84 @@ class ViewController: NSViewController {
             // Populate information initially.
             // We cannot obtain a store URL initially.
             Task(priority: .userInitiated) {
-                await self.updateEmbed(storeUrl: nil)
+                await self.updateRichPresence(playerState: self.player.state.value)
             }
         }
 
-        // iTunes/Music send out a NSNotification upon various state changes.
-        // We should update the embed on these events.
-        DistributedNotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "\(appName).playerInfo"), object: nil, queue: nil, using: { provided in
+        playerSink = player.state.sink { state in
             Task(priority: .userInitiated) {
-                // We use provided only to obtain the store URL.
-                let storeUrl: String? = provided.userInfo?["Store URL"] as? String ?? nil
-                await self.updateEmbed(storeUrl: storeUrl)
+                await self.updateRichPresence(playerState: state)
             }
-        })
+        }
 
         rpc.connect()
     }
 
-    func updateEmbed(storeUrl: String?) async {
+    func updateRichPresence(playerState state: PlayerState) async {
         var presence = RichPresence()
 
-        // By default, show a lack of state.
-        presence.details = "Stopped"
-        presence.state = "Nothing is currently playing"
-        presence.assets.largeImage = assetName
-        presence.assets.largeText = "There's nothing here!"
-        presence.assets.smallImage = "stop"
-        presence.assets.smallText = "Currently stopped"
+        func updateActive(_ active: PlayerState.Active, paused: Bool = false) async {
+            log.info("Player is active, populating rich presence state accordingly")
 
-        let itunes: AnyObject = SBApplication(bundleIdentifier: appName)!
-        let track = itunes.currentTrack
-        if track != nil {
-            // Something's doing something, player can't be nil.. right?
-            let playerState = itunes.playerState!
+            let track = active.track
+            presence.details = track.title
+            presence.state = "\(track.artist ?? "Unknown") \u{2014} \(track.album ?? "Unknown")"
 
-            // Something's marked as playing, time to see..
-            let sureTrack = track!
-
-            presence.state = "\(sureTrack.artist!) \u{2014} \(sureTrack.album!)"
-            presence.assets.largeText = "\(sureTrack.name!)"
             presence.assets.largeImage = assetName
+            presence.assets.largeText = track.title
+            presence.assets.smallImage = paused ? "pause" : "play"
+            presence.assets.smallText = paused ? "Paused" : "Playing"
 
-            switch playerState {
-            case .iTunesEPlSPlaying:
-                presence.details = "\(sureTrack.name!)"
-                presence.assets.smallImage = "play"
-                presence.assets.smallText = "Playing"
-
-                // Determine if this song is available on the iTunes Store.
-                // It's okay if it is not - we default to the Music icon.
-                if storeUrl != nil {
-                    let artworkURL = await obtainAlbumArt(url: storeUrl!)
-                    if artworkURL != nil {
-                        presence.assets.largeImage = artworkURL!
+            if track.url != nil {
+                log.debug("Attempting to fetch artwork.")
+                do {
+                    if let artworkUrl = try await player.fetchArtwork(forTrack: track) {
+                        presence.assets.largeImage = artworkUrl.absoluteString
                     }
+                } catch {
+                    log.error("Failed to obtain artwork for track \(String(describing: track)): \(String(describing: error))")
                 }
+            } else {
+                log.debug("Track has no URL; not going to try to fetch artwork.")
+            }
 
-                // The following needs to be in milliseconds.
-                let trackDuration = Double(round(sureTrack.duration!))
-                let trackPosition = Double(round(itunes.playerPosition!))
-                let currentTimestamp = Date()
-                let trackSecondsRemaining = trackDuration - trackPosition
+            if !paused {
+                let now = Date()
+                let startTimestamp = now - active.position
+                let endTimestamp = now + (track.duration - active.position)
 
-                let startTimestamp = currentTimestamp - trackPosition
-                let endTimestamp = currentTimestamp + trackSecondsRemaining
+                log.debug("Claimed track duration: \(track.duration), claimed active position: \(active.position)")
+                log.debug("Start timestamp: \(startTimestamp); end timestamp: \(endTimestamp)")
 
-                // Go back (position amount)
+                // Time that the track was started
                 presence.timestamps.start = Date(timeIntervalSince1970: startTimestamp.timeIntervalSince1970 * 1000)
 
-                // Add time remaining
+                // Time that the track ends
                 presence.timestamps.end = Date(timeIntervalSince1970: endTimestamp.timeIntervalSince1970 * 1000)
-            case .iTunesEPlSPaused:
-                presence.details = "Paused: \(sureTrack.name!)"
-                presence.assets.smallImage = "pause"
-                presence.assets.smallText = "Paused"
-            default:
-                break
             }
         }
 
+        switch state {
+        case .stopped:
+            presence.details = "Stopped"
+            presence.state = "Nothing is currently playing"
+
+            presence.assets.largeImage = assetName
+            presence.assets.largeText = "There's nothing here!"
+            presence.assets.smallImage = "stop"
+            presence.assets.smallText = "Currently stopped"
+
+        // If the player is active (i.e. has a track and position), then update
+        // the rich presence accordingly.
+        case .playing(let active):
+            await updateActive(active, paused: false)
+        case .paused(let active):
+            await updateActive(active, paused: true)
+        }
+
+        log.info("Sending presence: \(String(describing: presence))")
+
         rpc.setPresence(presence)
-    }
-
-    func obtainAlbumArt(url: String) async -> String? {
-        let result = await MusicAuthorization.request()
-        guard result == .authorized else {
-            // It may be that the user denied.
-            return nil
-        }
-
-        // Determine the song ID from our given itms url.
-        // We expect a format similar to itmss://itunes.com/album?p=1525065667&i=1525065832.
-        guard let songUrl = URLComponents(string: url) else {
-            return nil
-        }
-
-        // We obtain query items and search for "i".
-        guard let queryParam = songUrl.queryItems?.filter({ $0.name == "i" }).first else {
-            return nil
-        }
-        guard let queryId = queryParam.value else {
-            return nil
-        }
-
-        // Request the song for the given ID.
-        var request = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID(stringLiteral: queryId))
-        request.limit = 1
-
-        // Attempt the request.
-        var response: MusicCatalogResourceResponse<Song>
-        do {
-            response = try await request.response()
-        } catch let e {
-            // Don't even bother catching the error.
-            print(e)
-            return nil
-        }
-
-        // Seems we could not find the song.
-        if response.items.isEmpty {
-            return nil
-        }
-
-        let song = response.items.first!
-        let artwork = song.artwork?.url(width: 512, height: 512)
-        if artwork == nil {
-            return nil
-        } else {
-            return artwork?.absoluteString
-        }
-    }
-
-    override var representedObject: Any? {
-        didSet {
-            // Update the view, if already loaded.
-        }
     }
 }
 


### PR DESCRIPTION
Most of this patch consists of decoupling the "what's playing right now" logic from the view controller. Multiple structures were added to make things clean and tidy. As a result of this, it's now easier to hypothetically implement another player. The app won't have any trouble sending rich presences from a new player given that all of the necessary information is returned.

In the future I'd like to make it possible to somehow upload the artwork of songs that aren't on Apple Music to some kind of CDN or host to be temporarily accessed by Discord, since I'd like the artwork of my local music to be visible there, too.

Also, a bunch of logging was added. Pop open a terminal and run `log stream --info --debug --predicate 'subsystem == "io.github.spotlightishere.Ongaku"'` for easy debugging. Certain levels are even persisted for debugging after the fact, but I didn't add any logging events that take advantage of that yet.