### PR TITLE
Improve Discord display

### DIFF
--- a/Ongaku.xcodeproj/project.pbxproj
+++ b/Ongaku.xcodeproj/project.pbxproj
@@ -696,8 +696,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/spotlightishere/SwordRPC";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		59453BE32C4090C2007E572F /* XCRemoteSwiftPackageReference "MacControlCenterUI" */ = {

--- a/Ongaku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ongaku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
-        "version" : "5.9.1"
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MacControlCenterUI",
       "state" : {
-        "revision" : "ed550581d3f904031eaccfe85962dac076bdd321",
-        "version" : "2.0.10"
+        "revision" : "ee2003b6508de0997cbe6ebb238801f297a450ab",
+        "version" : "2.4.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MenuBarExtraAccess",
       "state" : {
-        "revision" : "f5896b47e15e114975897354c7e1082c51a2bffd",
-        "version" : "1.0.5"
+        "revision" : "707dff6f55217b3ef5b6be84ced3e83511d4df5c",
+        "version" : "1.2.2"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "9746cf80e29edfef2a39924a66731249223f42a3",
-        "version" : "2.72.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
-        "version" : "1.3.2"
+        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
+        "version" : "1.6.2"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/spotlightishere/SwordRPC",
       "state" : {
-        "revision" : "c3bad9b0cb66b4afc53394a7d67206f2b47b00a3",
-        "version" : "1.1.0"
+        "branch" : "main",
+        "revision" : "862f44d5a05bcdba551f2b4f93db1174306fd331"
       }
     }
   ],

--- a/Ongaku/Player/MusicPlayer.swift
+++ b/Ongaku/Player/MusicPlayer.swift
@@ -79,6 +79,8 @@ private func fetchPlayerState() throws -> PlayerState {
 
 class MusicPlayer: Player {
     var state: CurrentValueSubject<PlayerState, Never>
+    var webUrl: URL?
+    var artistUrl: URL?
 
     fileprivate var sink: AnyCancellable?
 
@@ -176,6 +178,9 @@ class MusicPlayer: Player {
         else {
             return nil
         }
+        self.webUrl = song.url
+        self.artistUrl = song.artistURL
+        // If we could iterate song.artists and link multiple artists like Spotify does...
         return artwork
     }
 

--- a/Ongaku/Player/Player.swift
+++ b/Ongaku/Player/Player.swift
@@ -15,4 +15,10 @@ protocol Player {
 
     /// Fetches a URL to the artwork of a track.
     func fetchArtwork(forTrack track: Track) async throws -> URL?
+    
+    /// The URL of this track on the website.
+    var webUrl: URL? { get }
+    
+    /// The artist's website URL.
+    var artistUrl: URL? { get }
 }

--- a/Ongaku/RPCController.swift
+++ b/Ongaku/RPCController.swift
@@ -52,12 +52,12 @@ class RPCController: SwordRPCDelegate, ObservableObject {
         if !enabled { return }
 
         var presence = RichPresence()
+        presence.type = .listening
 
         func updateActive(_ active: PlayerState.Active, paused: Bool = false) async {
             log.info("Player is active, populating rich presence state accordingly")
 
             let track = active.track
-            presence.type = .listening
             presence.details = track.title
             presence.state = track.artist ?? "Unknown"
             presence.statusDisplayType = .details

--- a/Ongaku/RPCController.swift
+++ b/Ongaku/RPCController.swift
@@ -72,6 +72,8 @@ class RPCController: SwordRPCDelegate, ObservableObject {
                 do {
                     if let artworkUrl = try await player.fetchArtwork(forTrack: track) {
                         presence.assets.largeImage = artworkUrl.absoluteString
+                        presence.detailsUrl = player.webUrl?.absoluteString
+                        presence.stateUrl = player.artistUrl?.absoluteString
                     }
                 } catch {
                     log.error("Failed to obtain artwork for track \(String(describing: track)): \(String(describing: error))")

--- a/Ongaku/RPCController.swift
+++ b/Ongaku/RPCController.swift
@@ -59,10 +59,11 @@ class RPCController: SwordRPCDelegate, ObservableObject {
             let track = active.track
             presence.type = .listening
             presence.details = track.title
-            presence.state = "\(track.artist ?? "Unknown") \u{2014} \(track.album ?? "Unknown")"
+            presence.state = track.artist ?? "Unknown"
+            presence.statusDisplayType = .details
 
             presence.assets.largeImage = assetName
-            presence.assets.largeText = track.title
+            presence.assets.largeText = track.album ?? "Unknown album"
             presence.assets.smallImage = paused ? "pause" : "play"
             presence.assets.smallText = paused ? "Paused" : "Playing"
 


### PR DESCRIPTION
- Utilize new status display type (https://github.com/spotlightishere/SwordRPC/pull/5)
- Fixed issue where being in the paused/stopped states still used the "playing" activity type
- Added clickable links for the track and artist
    - (Note: `MusicKit.Artist.url` and `MusicKit.Song.artistUrl` both seem to always be `nil`)
- Updated package dependencies
    - (Please note that SwordRPC now resolves to the latest commit on the main branch)

<img width="585" height="516" alt="Screenshot 2025-08-17 at 14 30 07" src="https://github.com/user-attachments/assets/349435cf-d926-4844-b6fd-12a6ffa0b0fe" />
